### PR TITLE
[FUZB-65] Fix pre-commit autoupdate action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,6 @@ runs:
       shell: bash
       continue-on-error: true
     - name: Re-run pre-commit if failed
-      if: steps.run_pre_commit != 'success'
+      if: steps.run_pre_commit.outcome != 'success'
       run: pre-commit run --all-files
       shell: bash


### PR DESCRIPTION
This PR fixes the failure caused by when pre-commit action runs and the update results in changes. The solution is to use [steps context](https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context) to catch the error cause by `pre-commit run --all-files` when there's is a change, and then re-run `pre-commit run --all-files`.